### PR TITLE
Fix arity for template in eventlistener triggers

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -91,7 +91,7 @@ specifies the following fields:
 - `name` - (optional) a valid [Kubernetes name](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set) that uniquely identifies the `Trigger`
 - `interceptors` - (optional) a list of [`Interceptors`](#specifying-interceptors) that will process event payload data before passing it to the associated `TriggerBinding`
 - `bindings` - (optional) a list of `TriggerBindings` for this `Trigger`; you can either reference existing `TriggerBindings` or embed their definitions directly
-- `template` - (optional) a list of `TriggerTemplates` for this `Trigger`; you can either reference existing `TriggerTemplates` or embed their definitions directly
+- `template` - (optional) a `TriggerTemplate` for this `Trigger`; you can either reference an existing `TriggerTemplate` or embed its definition directly
 - `triggerRef` - (optional) a reference to an external [`Trigger`](./triggers.md)
 
 Below is an example `Trigger` definition that references the desired `TriggerBindings`, `TriggerTemplates`, and `Interceptors`:


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

I think a inside an `EventListener`, you can only specify a single `TriggerTemplate`, eg. the following works:

```yaml
apiVersion: triggers.tekton.dev/v1beta1
kind: EventListener
metadata:
  name: my-listener
spec:
  triggers:
    - bindings:
        - ref: my-binding
      template:
        ref: my-template
```

But this won't:

```yaml
apiVersion: triggers.tekton.dev/v1beta1
kind: EventListener
metadata:
  name: my-listener
spec:
  triggers:
    - bindings:
        - ref: my-binding
      template:
        - ref: my-template
        - ref: my-template
```

I've got this error when I tried to apply it:

```
admission webhook "webhook.triggers.tekton.dev" denied the request: mutation failed: cannot decode incoming new object: json: cannot unmarshal array into Go struct field EventListenerTrigger.spec.triggers.template of type v1beta1.TriggerSpecTemplate
```

(the same happened for both `triggers.tekton.dev/v1beta1` and `triggers.tekton.dev/v1alpha1`)

I'm definitely not an expert in tekton internals, but I found the following definitions, and it looks like that only a single `TriggerTemplate` is supported:

https://github.com/madbence/triggers/blob/c24f7e243f26339ab5138cb94b20e2f860d6748b/pkg/apis/triggers/v1alpha1/event_listener_types.go#L87-L102

https://github.com/madbence/triggers/blob/c24f7e243f26339ab5138cb94b20e2f860d6748b/pkg/apis/triggers/v1beta1/event_listener_types.go#L100-L115

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```